### PR TITLE
Reset shift after saving to return to normal function

### DIFF
--- a/lithops.lua
+++ b/lithops.lua
@@ -367,6 +367,7 @@ function key(n,z)
       until tape_overwrite == false
       softcut.buffer_write_mono (_path.audio.."lithops/".."lithopsloop"..tape_save..".wav",tape_loop,tape_length,0)
       print (_path.audio.."lithops/".."lithopsloop"..tape_save..".wav")
+      shift = 0
     end
   end
 end


### PR DESCRIPTION
Without this, it looks like `shift` gets stuck, so pressing K1+K3 to save and then pressing K3 for a fresh loop saves again instead.